### PR TITLE
chore: scaffold monorepo structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.pnpm-store
+.env
+.DS_Store
+coverage
+hardhat.cache
+artifacts
+.next
+out

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # LoopFi
+
+Monorepo for the LoopFi project. This repository uses pnpm workspaces to manage
+smart contracts, frontend, and backend packages.
+
+## Packages
+
+- `contracts` – Hardhat based smart contract development.
+- `frontend` – Next.js application with Tailwind CSS and shadcn/ui.
+- `backend` – Express server with Supabase client and shared data schema.
+
+## Development
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Run the frontend:
+
+```bash
+pnpm dev
+```
+
+Compile contracts:
+
+```bash
+pnpm --filter contracts build
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@loopfi/backend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "ts-node src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "echo \"no tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "@supabase/supabase-js": "^2.39.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "ts-node": "^10.9.2"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,12 @@
+import express from "express";
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.get("/", (_req, res) => {
+  res.send("LoopFi backend");
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -1,0 +1,28 @@
+export interface User {
+  id: string;
+  name: string;
+  roleId: string;
+}
+
+export interface Role {
+  id: string;
+  name: string;
+}
+
+export interface Loop {
+  id: string;
+  title: string;
+  vaultId: string;
+}
+
+export interface Vote {
+  id: string;
+  loopId: string;
+  userId: string;
+  weight: number;
+}
+
+export interface Vault {
+  id: string;
+  balance: string;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  }
+}

--- a/contracts/contracts/Lock.sol
+++ b/contracts/contracts/Lock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract Lock {
+    uint public unlockTime;
+    address payable public owner;
+
+    event Withdrawal(uint amount, uint when);
+
+    constructor(uint _unlockTime) payable {
+        require(block.timestamp < _unlockTime, "Unlock time should be in the future");
+        unlockTime = _unlockTime;
+        owner = payable(msg.sender);
+    }
+
+    function withdraw() public {
+        require(block.timestamp >= unlockTime, "You can't withdraw yet");
+        require(msg.sender == owner, "You aren't the owner");
+
+        emit Withdrawal(address(this).balance, block.timestamp);
+        owner.transfer(address(this).balance);
+    }
+}

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,0 +1,14 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.20",
+  paths: {
+    sources: "contracts",
+    tests: "test",
+    cache: "hardhat.cache",
+    artifacts: "artifacts"
+  }
+};
+
+export default config;

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@loopfi/contracts",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "hardhat compile",
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "typescript": "^5.3.3",
+    "ts-node": "^10.9.2",
+    "hardhat": "^2.19.0"
+  }
+}

--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -1,0 +1,16 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const currentTimestampInSeconds = Math.round(Date.now() / 1000);
+  const unlockTime = currentTimestampInSeconds + 60;
+  const lockedAmount = ethers.parseEther("0.001");
+  const Lock = await ethers.getContractFactory("Lock");
+  const lock = await Lock.deploy(unlockTime, { value: lockedAmount });
+  await lock.waitForDeployment();
+  console.log(`Lock with ${lockedAmount} deployed to ${lock.target}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/test/Lock.ts
+++ b/contracts/test/Lock.ts
@@ -1,0 +1,13 @@
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("Lock", function () {
+  it("Should set the right unlockTime", async function () {
+    const lockedAmount = ethers.parseEther("1");
+    const unlockTime = (await time.latest()) + 60;
+    const Lock = await ethers.getContractFactory("Lock");
+    const lock = await Lock.deploy(unlockTime, { value: lockedAmount });
+    expect(await lock.unlockTime()).to.equal(unlockTime);
+  });
+});

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["./scripts", "./test", "./typechain", "./hardhat.config.ts"]
+}

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">LoopFi</h1>
+    </main>
+  );
+}

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  }
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@loopfi/frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "shadcn-ui": "^0.7.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.55.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./pages/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "loopfi-monorepo",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "build": "pnpm -r build",
+    "dev": "pnpm --filter frontend dev"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'contracts'
+  - 'frontend'
+  - 'backend'


### PR DESCRIPTION
## Summary
- initialize pnpm workspace with contracts, frontend, and backend packages
- add Hardhat sample contract project
- add Next.js + Tailwind + shadcn frontend skeleton
- add Express backend with Supabase client and TypeScript schema

## Testing
- `pnpm install --lockfile-only` (fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)
- `pnpm -r test` (fails: @loopfi/contracts@0.1.0 test: `hardhat test` spawn ENOENT)


------
https://chatgpt.com/codex/tasks/task_e_688f826987a88326b153e93f9098b265