### PR TITLE
Add OpenZeppelin contracts to dev dependencies

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -10,6 +10,7 @@
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",
     "typescript": "^5.3.3",
     "ts-node": "^10.9.2",
-    "hardhat": "^2.19.0"
+    "hardhat": "^2.19.0",
+    "@openzeppelin/contracts": "^5.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- resolve merge markers in `contracts/package.json`
- include `@openzeppelin/contracts` in dev dependencies

## Testing
- `pnpm --filter contracts install` *(fails: GET https://registry.npmjs.org/hardhat: Forbidden - 403)*
- `pnpm --filter contracts test` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_688f873794388326afbd6a060ae8f122