### PR TITLE
docs: resolve README conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ smart contracts, frontend, and backend packages.
 
 ## Packages
 
-- `contracts` – Hardhat based smart contract development.
+- `contracts` – Hardhat based smart contract development for LoopFi's DeFi protocol. It includes comprehensive tests and deployment scripts.
 - `frontend` – Next.js application with Tailwind CSS and shadcn/ui.
 - `backend` – Express server with Supabase client and shared data schema.
 
@@ -27,4 +27,10 @@ Compile contracts:
 
 ```bash
 pnpm --filter contracts build
+```
+
+Run contract tests:
+
+```bash
+pnpm --filter contracts test
 ```


### PR DESCRIPTION
## Summary
- clarify contract package details in README and document contract test command

## Testing
- `pnpm --filter contracts test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_688f87348fa483268875c03d3038fe01