### PR TITLE
feat: add loop contracts and tests

### DIFF
--- a/contracts/contracts/LoopFactory.sol
+++ b/contracts/contracts/LoopFactory.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {LoopVault} from "./LoopVault.sol";
+import {LoopRoleNFT} from "./LoopRoleNFT.sol";
+import {LoopOracle} from "./LoopOracle.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title LoopFactory
+/// @notice Deploys LoopVaults and assigns roles
+contract LoopFactory is Ownable {
+    LoopRoleNFT public immutable roleNFT;
+    LoopOracle public immutable oracle;
+
+    constructor(address _roleNFT, address _oracle) Ownable(msg.sender) {
+        roleNFT = LoopRoleNFT(_roleNFT);
+        oracle = LoopOracle(_oracle);
+    }
+
+    /// @notice Deploy a new LoopVault
+    /// @param token Address of ERC20 token or zero for ETH
+    /// @param beneficiary Address receiving released funds
+    function createLoop(address token, address beneficiary) external onlyOwner returns (address) {
+        LoopVault vault = new LoopVault(token, beneficiary, address(oracle));
+        roleNFT.mintRole(beneficiary, "beneficiary");
+        return address(vault);
+    }
+}

--- a/contracts/contracts/LoopOracle.sol
+++ b/contracts/contracts/LoopOracle.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title LoopOracle
+/// @notice Manual validation module used to approve vault releases
+contract LoopOracle is Ownable {
+    mapping(address => bool) public approved;
+
+    constructor() Ownable(msg.sender) {}
+
+    /// @notice Mark a vault as approved for release
+    function validate(address vault) external onlyOwner {
+        approved[vault] = true;
+    }
+}

--- a/contracts/contracts/LoopRoleNFT.sol
+++ b/contracts/contracts/LoopRoleNFT.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title LoopRoleNFT
+/// @notice Soulbound NFT used to assign roles in LoopFi
+contract LoopRoleNFT is ERC721, Ownable {
+    uint256 public nextId;
+    mapping(uint256 => string) public roles;
+    mapping(address => bool) public hasRole;
+
+    constructor() ERC721("LoopRoleNFT", "LRN") Ownable(msg.sender) {}
+
+    /// @notice Mint a role NFT to `to`
+    /// @param to Address receiving the role
+    /// @param role String identifier of the role
+    function mintRole(address to, string memory role) external onlyOwner returns (uint256) {
+        require(!hasRole[to], "Role already assigned");
+        uint256 tokenId = ++nextId;
+        _safeMint(to, tokenId);
+        roles[tokenId] = role;
+        hasRole[to] = true;
+        return tokenId;
+    }
+
+    /// @dev Soulbound: disable approvals
+    function approve(address, uint256) public pure override {
+        revert("Soulbound");
+    }
+
+    /// @dev Soulbound: disable approvals
+    function setApprovalForAll(address, bool) public pure override {
+        revert("Soulbound");
+    }
+
+    /// @dev Soulbound: only allow minting or burning
+    function _transfer(address from, address to, uint256 tokenId) internal override {
+        require(from == address(0) || to == address(0), "Soulbound");
+        super._transfer(from, to, tokenId);
+    }
+}

--- a/contracts/contracts/LoopVault.sol
+++ b/contracts/contracts/LoopVault.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {LoopOracle} from "./LoopOracle.sol";
+
+/// @title LoopVault
+/// @notice Holds funds and releases them once validated by the oracle
+contract LoopVault {
+    address public immutable token; // address(0) for ETH
+    address public immutable beneficiary;
+    LoopOracle public immutable oracle;
+    bool public released;
+
+    constructor(address _token, address _beneficiary, address _oracle) {
+        token = _token;
+        beneficiary = _beneficiary;
+        oracle = LoopOracle(_oracle);
+    }
+
+    /// @notice Deposit funds into the vault
+    /// @param amount Amount of ERC20 tokens to deposit (ignored for ETH)
+    function deposit(uint256 amount) external payable {
+        if (token == address(0)) {
+            require(msg.value > 0, "No ETH sent");
+        } else {
+            require(msg.value == 0, "ETH not accepted");
+            IERC20(token).transferFrom(msg.sender, address(this), amount);
+        }
+    }
+
+    /// @notice Release funds to the beneficiary if approved by the oracle
+    function release() external {
+        require(!released, "Already released");
+        require(oracle.approved(address(this)), "Not approved");
+        released = true;
+        if (token == address(0)) {
+            (bool ok, ) = beneficiary.call{value: address(this).balance}("");
+            require(ok, "ETH transfer failed");
+        } else {
+            IERC20 erc20 = IERC20(token);
+            erc20.transfer(beneficiary, erc20.balanceOf(address(this)));
+        }
+    }
+}

--- a/contracts/contracts/MockERC20.sol
+++ b/contracts/contracts/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("MockUSD", "MUSDC") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/test/Loop.ts
+++ b/contracts/test/Loop.ts
@@ -1,0 +1,63 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+const ZERO = ethers.ZeroAddress;
+
+describe("Loop contracts", function () {
+  it("handles ETH deposit and release after oracle validation", async function () {
+    const [deployer, beneficiary, depositor] = await ethers.getSigners();
+
+    const Role = await ethers.getContractFactory("LoopRoleNFT");
+    const role = await Role.deploy();
+    const Oracle = await ethers.getContractFactory("LoopOracle");
+    const oracle = await Oracle.deploy();
+    const Factory = await ethers.getContractFactory("LoopFactory");
+    const factory = await Factory.deploy(await role.getAddress(), await oracle.getAddress());
+
+    const predicted = await factory.callStatic.createLoop(ZERO, beneficiary.address);
+    await factory.createLoop(ZERO, beneficiary.address);
+    const vault = await ethers.getContractAt("LoopVault", predicted);
+
+    expect(await role.balanceOf(beneficiary.address)).to.equal(1n);
+    await expect(
+      role.connect(beneficiary).transferFrom(beneficiary.address, depositor.address, 1n)
+    ).to.be.revertedWith("Soulbound");
+
+    const depositAmount = ethers.parseEther("1");
+    await vault.connect(depositor).deposit(0, { value: depositAmount });
+    await expect(vault.connect(beneficiary).release()).to.be.revertedWith("Not approved");
+
+    await oracle.validate(predicted);
+    await expect(() => vault.connect(beneficiary).release()).to.changeEtherBalances(
+      [vault, beneficiary],
+      [-depositAmount, depositAmount]
+    );
+  });
+
+  it("handles ERC20 deposit and release", async function () {
+    const [deployer, beneficiary, depositor] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockERC20");
+    const token = await Token.deploy();
+    await token.mint(depositor.address, 1000n);
+
+    const Role = await ethers.getContractFactory("LoopRoleNFT");
+    const role = await Role.deploy();
+    const Oracle = await ethers.getContractFactory("LoopOracle");
+    const oracle = await Oracle.deploy();
+    const Factory = await ethers.getContractFactory("LoopFactory");
+    const factory = await Factory.deploy(await role.getAddress(), await oracle.getAddress());
+
+    const predicted = await factory.callStatic.createLoop(await token.getAddress(), beneficiary.address);
+    await factory.createLoop(await token.getAddress(), beneficiary.address);
+    const vault = await ethers.getContractAt("LoopVault", predicted);
+
+    await token.connect(depositor).approve(predicted, 500n);
+    await vault.connect(depositor).deposit(500n);
+
+    await expect(vault.release()).to.be.revertedWith("Not approved");
+    await oracle.validate(predicted);
+    await vault.release();
+    expect(await token.balanceOf(beneficiary.address)).to.equal(500n);
+  });
+});


### PR DESCRIPTION
## Summary
- implement LoopRoleNFT soulbound role token
- add LoopOracle, LoopVault, LoopFactory, and mock ERC20
- add tests covering ETH and ERC20 deposits

## Testing
- `npx hardhat test` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_688f8a7c9fec8326ae7e81f2b3445443