### PR TITLE
feat: add minimal loop UI

### DIFF
--- a/frontend/app/create/page.tsx
+++ b/frontend/app/create/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function CreateLoop() {
+  const [token, setToken] = useState('');
+  const [beneficiary, setBeneficiary] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const router = useRouter();
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setMessage('');
+    // Simulate async contract call
+    setTimeout(() => {
+      setLoading(false);
+      setMessage('Loop créée!');
+      // redirect to example loop page
+      router.push('/loop/demo');
+    }, 1000);
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Créer une loop</h1>
+      <form onSubmit={submit} className="space-y-2 max-w-md">
+        <input
+          className="w-full border p-2"
+          placeholder="Adresse du token (0x0 pour ETH)"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+        />
+        <input
+          className="w-full border p-2"
+          placeholder="Adresse du bénéficiaire"
+          value={beneficiary}
+          onChange={(e) => setBeneficiary(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2"
+          disabled={loading}
+        >
+          {loading ? 'Création...' : 'Créer'}
+        </button>
+      </form>
+      {message && <p className="text-green-600">{message}</p>}
+    </main>
+  );
+}
+

--- a/frontend/app/loop/[id]/page.tsx
+++ b/frontend/app/loop/[id]/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default function LoopPage({ params }: PageProps) {
+  const [capital, setCapital] = useState(0);
+  const [amount, setAmount] = useState('');
+  const [roleJoined, setRoleJoined] = useState(false);
+  const [roleCompleted, setRoleCompleted] = useState(false);
+  const [message, setMessage] = useState('');
+  const isAdmin = true; // Demo purpose
+
+  const notify = (msg: string) => {
+    setMessage(msg);
+    setTimeout(() => setMessage(''), 3000);
+  };
+
+  const joinRole = () => {
+    if (roleJoined) return;
+    if (confirm('Mint NFT pour ce rôle ?')) {
+      setRoleJoined(true);
+      notify('Rôle rejoint');
+    }
+  };
+
+  const stake = () => {
+    const val = parseFloat(amount);
+    if (isNaN(val) || val <= 0) return;
+    if (confirm(`Staker ${val} USDC ?`)) {
+      setCapital((c) => c + val);
+      setAmount('');
+      notify('USDC staké');
+    }
+  };
+
+  const complete = () => {
+    if (confirm('Marquer comme complété ?')) {
+      setRoleCompleted(true);
+      notify('Rôle complété');
+    }
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Loop {params.id}</h1>
+      <div>
+        <p>Capital collecté: {capital} USDC</p>
+        <p>Statut: {roleCompleted ? 'Terminé' : 'En cours'}</p>
+      </div>
+      <div className="space-x-2">
+        <button
+          onClick={joinRole}
+          disabled={roleJoined}
+          className="bg-green-600 text-white px-4 py-2"
+        >
+          {roleJoined ? 'Rôle rejoint' : 'Rejoindre un rôle'}
+        </button>
+        <input
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="Montant"
+          className="border p-2 w-24"
+        />
+        <button
+          onClick={stake}
+          className="bg-blue-600 text-white px-4 py-2"
+        >
+          Capitaliser
+        </button>
+      </div>
+      {isAdmin && !roleCompleted && (
+        <button
+          onClick={complete}
+          className="bg-purple-600 text-white px-4 py-2"
+        >
+          Marquer complété
+        </button>
+      )}
+      {message && <p className="text-green-600">{message}</p>}
+    </main>
+  );
+}
+

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,17 @@
+import Link from "next/link";
+
 export default function Home() {
   return (
-    <main className="p-4">
+    <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">LoopFi</h1>
+      <div className="space-x-4">
+        <Link href="/create" className="text-blue-600 underline">
+          Créer une loop
+        </Link>
+        <Link href="/loop/demo" className="text-blue-600 underline">
+          Exemple de loop
+        </Link>
+      </div>
     </main>
   );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,10 +15,13 @@
     "shadcn-ui": "^0.7.0"
   },
   "devDependencies": {
-    "typescript": "^5.3.3",
-    "tailwindcss": "^3.4.1",
-    "postcss": "^8.4.31",
+    "@types/node": "24.1.0",
+    "@types/react": "19.1.9",
     "autoprefixer": "^10.4.14",
-    "eslint": "^8.55.0"
+    "eslint": "^8.55.0",
+    "eslint-config-next": "^15.4.5",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- add links on home page to create or view a loop
- basic form to create a loop with mock feedback
- loop page to join a role, stake USDC, and complete roles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f95aa4dac8326a56427f18037fa99