### PR TITLE
feat: add export endpoints for loops and roles

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,11 +9,12 @@
     "test": "echo \"no tests\""
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "@supabase/supabase-js": "^2.39.0"
+    "@supabase/supabase-js": "^2.39.0",
+    "express": "^4.18.2"
   },
   "devDependencies": {
-    "typescript": "^5.3.3",
-    "ts-node": "^10.9.2"
+    "@types/express": "^5.0.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
   }
 }

--- a/backend/src/data.ts
+++ b/backend/src/data.ts
@@ -1,0 +1,20 @@
+import { Loop, Role } from "./schema";
+
+export const loops: Loop[] = [
+  {
+    id: "1",
+    title: "Example Loop",
+    vaultId: "vault1",
+  },
+];
+
+export const roles: Role[] = [
+  {
+    id: "1",
+    name: "Admin",
+  },
+  {
+    id: "2",
+    name: "Participant",
+  },
+];

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,10 +1,39 @@
-import express from "express";
+import express, { Request, Response } from "express";
+import { loops, roles } from "./data";
 
 const app = express();
 const port = process.env.PORT || 3001;
 
-app.get("/", (_req, res) => {
+function toCSV(items: any[]): string {
+  if (items.length === 0) return "";
+  const headers = Object.keys(items[0]);
+  const csvRows = [
+    headers.join(","),
+    ...items.map((item) => headers.map((h) => String(item[h] ?? "")).join(",")),
+  ];
+  return csvRows.join("\n");
+}
+
+app.get("/", (_req: Request, res: Response) => {
   res.send("LoopFi backend");
+});
+
+app.get("/export/loops", (req: Request, res: Response) => {
+  const format = String(req.query.format || "json").toLowerCase();
+  if (format === "csv") {
+    res.type("text/csv").send(toCSV(loops));
+  } else {
+    res.json(loops);
+  }
+});
+
+app.get("/export/roles", (req: Request, res: Response) => {
+  const format = String(req.query.format || "json").toLowerCase();
+  if (format === "csv") {
+    res.type("text/csv").send(toCSV(roles));
+  } else {
+    res.json(roles);
+  }
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- add endpoints to export loops and roles in JSON or CSV
- seed the backend with example loops and roles for exports

## Testing
- `cd backend && npm run build`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f988b12c88326af64d83e5aef73cb